### PR TITLE
Define all build tools in one place

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -30,8 +30,8 @@ plugins {
 val projectMinSdk: String by project
 val projectTargetSdk: String by project
 val projectCompileSdk: String by project
-val projectBuildToolsVersion: String by project
-val projectNdkVersion: String by project
+val projectBuildToolsVersion = project.findProperty("build.tools.version") as String
+val projectNdkVersion: String = project.findProperty("build.ndk.version") as String
 val projectVersionCode: String by project
 val projectVersionName: String by project
 val projectVersionNameSuffix = projectVersionName.substringAfter("-", "")
@@ -150,6 +150,7 @@ android {
 
     aboutLibraries {
         configPath = "app/src/main/config"
+        excludeFields = arrayOf("generated")
     }
 
     testOptions {

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,8 +10,15 @@ org.gradle.warning.mode=all
 projectMinSdk=24
 projectTargetSdk=34
 projectCompileSdk=34
-projectBuildToolsVersion=34.0.0
-projectNdkVersion=26.1.10909125
-
 projectVersionCode=97
 projectVersionName=0.4.0-rc02
+
+### Reproducible build config ###
+build.rustup.version=1.24.3
+build.rust_toolchain.version=1.83.0
+build.cmake.version=3.30.5
+build.ninja.version=1.11.1
+build.ndk.version=26.1.10909125
+build.jdk.version=17.0.13+11
+build.jdk.distribution=temurin
+build.tools.version=34.0.0

--- a/lib/native/build.gradle.kts
+++ b/lib/native/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 
 val projectMinSdk: String by project
 val projectCompileSdk: String by project
-val projectNdkVersion: String by project
+val projectNdkVersion = project.findProperty("build.ndk.version") as String
 
 android {
     namespace = "org.florisboard.libnative"


### PR DESCRIPTION
i like to accepted that for this project

## Summary by Sourcery

Centralize build tool version definitions in gradle.properties and update build scripts to reference these properties for improved maintainability and consistency.

Enhancements:
- Update build scripts to reference build tool versions from gradle.properties, improving maintainability.

Build:
- Centralize the definition of build tool versions in gradle.properties for easier management and consistency.